### PR TITLE
Ap/parameterization

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,33 @@ An extensive list of references for the tools used by the pipeline can be found 
 
 This pipeline uses code and infrastructure developed and maintained by the [nf-core](https://nf-co.re) community, reused here under the [MIT license](https://github.com/nf-core/tools/blob/master/LICENSE).
 
+## Parameter specification
+TODO: This is a work in progress
+We have set sensible parameter choices as default for each module, however several modules have parameters that are best-suited to user specification on a per-analysis basis. The section below describes, for each module, how these specifications are to be made as well as what some common specifications may be. Where necessary, refer to the documentation of each respective software for a more complete list of possible parameter choices.
+
+### Module:
+#### ANNOTATE_UNIPROT:
+ i) "download_annots": Specified in the parameter file. Parameter may be specified as one of three things: 
+  a) "all" - download all 15 possible sets of protein annotations from UniProt where possible. 
+  b) "none" - download only the minimum necessary annotations that are used by cogeqc for orthogroup inference quality assessments
+  c) A quoted, comma separated string of numbers 1-5: example "1,2,4,7,10". Numbers correspond to the index of annotations the user would like to download. See below for the correspondance and brief description of each annotation. For indices 4-16 (in particular) see https://www.uniprot.org/help/return_fields.
+   1: Minimal set of protein annotations/metadata required for COGEQC orthogroup inference. Include protein external IDs for InterPro, SupFam, ProSite, HOGENOM, OMA, and OrthoDB
+   2: General protein metadata, including protein name, length, mass, information from mass spec experiments, host organisms (for viral proteins), which organelle (if relevant) encoding the protein, and any AA variants due to RNA editing.
+   3: Gene ontologies - biological process, cellular component, molecular function, ontology ID
+   4: Function: Multiple annotations pertaining to the molecular function of the protein
+   5: Interactions
+   6: Protein-protein interactions (external database reference IDs)
+   7: Pathology & biotech
+   8: Subcellular location
+   9: Post-translation modification (PTM) / processsing
+   10: PTM databases 
+   11: Protein family & domains
+   12: Protein family/group databases
+   13: Sequence databases
+   14: 3D structure databases
+   15: Enzyme and pathway databases
+   16: Phylogenomic databases
+
 > **The nf-core framework for community-curated bioinformatics pipelines.**
 >
 > Philip Ewels, Alexander Peltzer, Sven Fillinger, Harshil Patel, Johannes Alneberg, Andreas Wilm, Maxime Ulysse Garcia, Paolo Di Tommaso & Sven Nahnsen.

--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ We have set sensible parameter choices as default for each module, however sever
 ### Module:
 #### ANNOTATE_UNIPROT:
  i) "download_annots": Specified in the parameter file. Parameter may be specified as one of three things: 
-  a) "all" - download all 15 possible sets of protein annotations from UniProt where possible. 
+  a) "all" - download all 16 possible sets of protein annotations from UniProt where possible. 
   b) "none" - download only the minimum necessary annotations that are used by cogeqc for orthogroup inference quality assessments
-  c) A quoted, comma separated string of numbers 1-5: example "1,2,4,7,10". Numbers correspond to the index of annotations the user would like to download. See below for the correspondance and brief description of each annotation. For indices 4-16 (in particular) see https://www.uniprot.org/help/return_fields.
+  c) A quoted, comma separated string of select numbers 1-16: example "1,2,4,7,10". Numbers correspond to the index of annotations the user would like to download. See below for the correspondance and brief description of each annotation. For indices 4-16 (in particular) see https://www.uniprot.org/help/return_fields.
    1: Minimal set of protein annotations/metadata required for COGEQC orthogroup inference. Include protein external IDs for InterPro, SupFam, ProSite, HOGENOM, OMA, and OrthoDB
    2: General protein metadata, including protein name, length, mass, information from mass spec experiments, host organisms (for viral proteins), which organelle (if relevant) encoding the protein, and any AA variants due to RNA editing.
    3: Gene ontologies - biological process, cellular component, molecular function, ontology ID

--- a/bin/UniProt-Protein-Annotation-NF.R
+++ b/bin/UniProt-Protein-Annotation-NF.R
@@ -4,12 +4,15 @@ library(UniProt.ws)
 
 args = commandArgs(trailingOnly=TRUE)
 
+# Pull the string specifying annotations to download
+annots_to_download <- args[1]
+
 # Pull out the species names - this is to be specified from the commandline
-spp <- args[1]
+spp <- args[2]
 
 # Get the filepath to the protein accessions we'll be mapping.
 # Also specified from the commandline.
-ids <- args[2]
+ids <- args[3]
 
 # Because this is going to be a fair bit of information,
 # let's make a new directory to house these outputs/gene ontologies,
@@ -115,7 +118,16 @@ tax_id <- UniProt.ws::queryUniProt(paste0("accession:", accessions[1]),
 up <- UniProt.ws::UniProt.ws(tax_id)
 
 # And pull down annotations, removing rows for proteins without any annotations.
-for(i in 1:15){
+# We now use the annots_to_download user variable to determine which we are
+# downloading. 
+if (annots_to_download == "all") {
+    anns <- 1:15
+} else if (annots_to_download == "none") {
+    anns <- 1
+} else {
+    anns <- annots_to_download
+}
+for(i in anns){
     annots <- UniProt.ws::select(up, accessions, c(common_cols, annotations[[i]]), 'UniProtKB')
     to_drop <- which(rowSums(is.na(annots[,-c(1:4)])) == ncol(annots[,-c(1:4)]))
 

--- a/bin/UniProt-Protein-Annotation-NF.R
+++ b/bin/UniProt-Protein-Annotation-NF.R
@@ -93,20 +93,19 @@ seq_xortho <-
     'xref_eggnog')
 
 annotations <- list(
-    seq_cogeqc, seq_meta, seq_funcs, seq_inter,
+    seq_cogeqc, seq_meta, seq_gos, seq_funcs, seq_inter,
     seq_interdbs, seq_biotech, seq_localize, seq_ptm,
     seq_xptmdb, seq_domains, seq_xfamdom, seq_xseqdbs,
     seq_x3ddbs, seq_xenzpath, seq_xortho
     )
 
 annot_names <-
-    c('-cogeqc-annotations.tsv', '-prot-metadat.tsv', '-prot-functions.tsv',
-    '-prot-interactions.tsv', '-prot-interactions-xref.tsv',
-    '-prot-biotech-annots.tsv', '-prot-localization.tsv',
-    '-prot-post-trans-mods.tsv', '-prot-post-trans-mods-xref.tsv',
-    '-prot-fams-domains.tsv', '-prot-fams-domains-xref.tsv',
-    '-prot-seq-dbs-xref.tsv', '-prot-3d-dbs-xref.tsv',
-    '-prot-enzyme-paths-xref.tsv', '-prot-orthology-dbs.tsv')
+    c('-cogeqc-annotations.tsv', '-prot-metadat.tsv', '-prot-gene-ontologies.tsv', 
+    '-prot-functions.tsv', '-prot-interactions.tsv', '-prot-interactions-xref.tsv',
+    '-prot-biotech-annots.tsv', '-prot-localization.tsv', '-prot-post-trans-mods.tsv', 
+    '-prot-post-trans-mods-xref.tsv', '-prot-fams-domains.tsv', '-prot-fams-domains-xref.tsv',
+    '-prot-seq-dbs-xref.tsv', '-prot-3d-dbs-xref.tsv', '-prot-enzyme-paths-xref.tsv', 
+    '-prot-orthology-dbs.tsv')
 
 # get the list of accessions for this species.
 accessions <- read.table(ids, sep = '\t')$V1
@@ -121,7 +120,7 @@ up <- UniProt.ws::UniProt.ws(tax_id)
 # We now use the annots_to_download user variable to determine which we are
 # downloading. 
 if (annots_to_download == "all") {
-    anns <- 1:15
+    anns <- 1:16
 } else if (annots_to_download == "none") {
     anns <- 1
 } else {

--- a/bin/og-tax-summary.R
+++ b/bin/og-tax-summary.R
@@ -38,6 +38,9 @@ numspp <- rowSums(ogs[-1], na.rm = T)
 for(i in 2:ncol(ogs)){
     # Identify the species
     spp <- colnames(ogs)[i]
+    
+    # Strip the EukProt ID (if relevant)
+    spp <- sub("EP0.*?_", "", spp)
 
     # And the taxonomic group for this species
     grp <- unique(as.character(samples$taxonomy[which(samples$species == spp)]))

--- a/bin/select_inflation.R
+++ b/bin/select_inflation.R
@@ -43,33 +43,42 @@ for(i in 1:length(vars)){
   # As a safety, check if the values are constant for all inflation parameters:
   # If so, we'll ignore these
   invariant[i] <- var(res$variable == vars[i]) == 0
-
-  if(i %in% c(1:3, 10:11)){
-    tmp.res <- res[which(res$variable == vars[i]),]
-    inflect <-
-      elbow(tmp.res[,c(1,3)])$inflation_param_selected
-    best[i] <- inflect
-
-    plts[[i]] <-
-      ggplot(data = tmp.res,
-             aes(x = inflation_param, y = value)) +
-      theme_classic() +
-      geom_vline(xintercept = inflect) +
-      geom_point(size = 3) +
-      geom_line() +
-      ylab(ylabs[i])
+  
+  # Get the results for this summary stat  
+  tmp.res <- res[which(res$variable == vars[i]),]
+  # A check to make sure that we are not dealing with missing values only
+  if(sum(is.na(tmp.res$value)) != length(tmp.res$value)){
+    if(i %in% c(4,8)){
+      # A check to make sure that we are not dealing with missing values only
+      inflect <-
+        elbow(tmp.res[,c(1,3)])$inflation_param_selected
+      best <- c(best, inflect)
+    
+      plts[[i]] <-
+        ggplot(data = tmp.res,
+               aes(x = inflation_param, y = value)) +
+        theme_classic() +
+        geom_vline(xintercept = inflect) +
+        geom_point(size = 3) +
+        geom_line() +
+        ylab(ylabs[i])
+    }else{      
+      plts[[i]] <-
+        ggplot(data = tmp.res,
+               aes(x = inflation_param, y = value)) +
+        geom_point(size = 3) +
+        geom_line() +
+        ylab(ylabs[i]) +
+        theme_classic()
+    }
   }else{
-    tmp.res <- res[which(res$variable == vars[i]),]
-    best[i] <- tmp.res$inflation_param[which(tmp.res$value == max(tmp.res$value))]
-
-    plts[[i]] <-
-      ggplot(data = tmp.res,
-             aes(x = inflation_param, y = value)) +
-      geom_vline(xintercept = best[i]) +
-      geom_point(size = 3) +
-      geom_line() +
-      ylab(ylabs[i]) +
-      theme_classic()
+      plts[[i]] <-
+        ggplot(data = tmp.res,
+               aes(x = inflation_param, y = value)) +
+        theme_classic() +
+        geom_point(size = 3) +
+        geom_line() +
+        ylab(ylabs[i])
   }
 }
 
@@ -79,7 +88,7 @@ og_summs <-
             plts[[9]], plts[[10]], plts[[11]],
             ncol = 4, nrow = 3)
 
-best_i <- mean(best[which(invariant == FALSE)])
+best_i <- mean(best)
 
 ggsave(og_summs, filename = 'inflation_summaries.pdf',
        height = 9, width = 12)

--- a/conf/base.config
+++ b/conf/base.config
@@ -7,6 +7,16 @@
     the PATH. Runs in `local` mode - all jobs will be run on the logged in environment.
 ----------------------------------------------------------------------------------------
 */
+// Set default parameters that may be overwritten
+params {
+    download_annots = 'none'
+    min_num_spp_per_og = '4'
+    min_num_grp_per_og = '1'
+    max_copy_num_spp_tree = '5'
+    max_copy_num_gene_trees = '10'
+    tree_model = 'TEST'
+    tree_model_pmsf = 'none'
+}
 
 process {
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -7,16 +7,6 @@
     the PATH. Runs in `local` mode - all jobs will be run on the logged in environment.
 ----------------------------------------------------------------------------------------
 */
-// Set default parameters that may be overwritten
-params {
-    download_annots = 'none'
-    min_num_spp_per_og = '4'
-    min_num_grp_per_og = '1'
-    max_copy_num_spp_tree = '5'
-    max_copy_num_gene_trees = '10'
-    tree_model = 'TEST'
-    tree_model_pmsf = 'none'
-}
 
 process {
 
@@ -25,9 +15,8 @@ process {
     memory = { check_max( 6.GB * task.attempt, 'memory' ) }
     time   = { check_max( 4.h  * task.attempt, 'time'   ) }
 
-    errorStrategy = { task.exitStatus in [143,137,104,134,139] ? 'retry' : 'finish' }
-    maxRetries    = 1
-    maxErrors     = '-1'
+    errorStrategy = { 'retry' }
+    maxRetries    = 3
 
     // Process-specific resource requirements
     // NOTE - Please try and re-use the labels below as much as possible.
@@ -53,17 +42,8 @@ process {
     }
     withLabel:process_high {
         cpus   = { check_max( 16    * task.attempt, 'cpus'    ) }
-        memory = { check_max( 36.GB * task.attempt, 'memory'  ) }
+        memory = { check_max( 24.GB * task.attempt, 'memory'  ) }
         time   = { check_max( 16.h  * task.attempt, 'time'    ) }
-    }
-    // This process (blast, speciesrax, mafft, iqtree, mcl) will benefit most 
-    // from being able to use a massive number of threads - the two cheapest 
-    // instance types with this number has 256Gb of memory, 
-    // hence this specification.
-    withLabel:process_highthread {
-        cpus   = { check_max( 128    * task.attempt, 'cpus'    ) }
-        memory = { check_max( 256.GB * task.attempt, 'memory'  ) }
-        time   = { check_max( 10.d  * task.attempt, 'time'    ) }
     }
     withLabel:process_long {
         time   = { check_max( 20.h  * task.attempt, 'time'    ) }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -11,13 +11,11 @@
 */
 
 process {
-
     publishDir = [
         path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
         mode: params.publish_dir_mode,
         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
     ]
-    
     withName: 'SAMPLESHEET_CHECK' {
         publishDir = [
             path: { "${params.outdir}/pipeline_info" },
@@ -25,10 +23,16 @@ process {
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
-    
     withName: 'DIAMOND_BLASTP' {
         ext.args = [
             '--ultra-sensitive'
         ].join(' ') 
     }
+    withName: 'MAFFT' {
+        ext.args = [
+            '--localpair',
+            '--maxiterate 1000',
+            '--anysymbol'
+        ].join(' ') 
+    }  
 }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -43,7 +43,15 @@ process {
             '--si-strategy HYBRID',
             '--si-quartet-support',
             '--si-estimate-bl',
-            '--strategy SPR',
+            '--strategy SPR'
+        ].join(' ') 
+    }
+    withName: 'GENERAX' {
+        ext.args = [
+            '--rec-model UndatedDTL',
+            '--prune-species-tree',
+            '--per-family-rates',
+            '--strategy SPR'
         ].join(' ') 
     }
 }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -35,4 +35,15 @@ process {
             '--anysymbol'
         ].join(' ') 
     }  
+    withName: 'SPECIESRAX' {
+        ext.args = [
+            '--per-family-rates',
+            '--rec-model UndatedDTL',
+            '--prune-species-tree',
+            '--si-strategy HYBRID',
+            '--si-quartet-support',
+            '--si-estimate-bl',
+            '--strategy SPR',
+        ].join(' ') 
+    }
 }

--- a/modules/local/annotate_uniprot.nf
+++ b/modules/local/annotate_uniprot.nf
@@ -12,8 +12,7 @@ process ANNOTATE_UNIPROT {
     )
 
     input:
-    tuple val(meta), path(fasta)
-    val annots_to_download
+    tuple val(annots_to_download), val(meta), path(fasta)
 
     output:
     path "*accessions.txt"  , emit: accessions

--- a/modules/local/annotate_uniprot.nf
+++ b/modules/local/annotate_uniprot.nf
@@ -6,7 +6,7 @@ process ANNOTATE_UNIPROT {
         '' }"
 
     publishDir(
-        path: "${params.outdir}/protein-annotations",
+        path: "${params.outdir}/protein_annotations",
         mode: params.publish_dir_mode,
         saveAs: { fn -> fn.substring(fn.lastIndexOf('/')+1) },
     )

--- a/modules/local/annotate_uniprot.nf
+++ b/modules/local/annotate_uniprot.nf
@@ -12,8 +12,9 @@ process ANNOTATE_UNIPROT {
     )
 
     input:
-    tuple val(annots_to_download), val(meta), path(fasta)
-
+    tuple val(meta), path(fasta)
+    val annots_to_download
+    
     output:
     path "*accessions.txt"  , emit: accessions
     path "*" , emit: all_annotations

--- a/modules/local/annotate_uniprot.nf
+++ b/modules/local/annotate_uniprot.nf
@@ -13,6 +13,7 @@ process ANNOTATE_UNIPROT {
 
     input:
     tuple val(meta), path(fasta)
+    val annots_to_download
 
     output:
     path "*accessions.txt"  , emit: accessions
@@ -40,7 +41,7 @@ process ANNOTATE_UNIPROT {
         # This R script uses the UniProt.ws bioconducter package to accomplish this.
         # NOTE: The script is packaged in the bin/ subdirectory of this workflow.
 
-        UniProt-Protein-Annotation-NF.R $spp ${spp}-protein-accessions.txt
+        UniProt-Protein-Annotation-NF.R $annots_to_download $spp ${spp}-protein-accessions.txt
     fi
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/asteroid.nf
+++ b/modules/local/asteroid.nf
@@ -33,7 +33,8 @@ process ASTEROID {
     asteroid \
     -i $treefile \
     -m $asteroid_map \
-    -p asteroid
+    -p asteroid \
+    $args
 
     # Version is hardcoded for now (asteroid doesn't output this currently)
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/clipkit.nf
+++ b/modules/local/clipkit.nf
@@ -6,7 +6,7 @@ process CLIPKIT {
         '' }"
 
     publishDir(
-        path: "${params.outdir}/trimmed-msas",
+        path: "${params.outdir}/trimmed_msas",
         mode: params.publish_dir_mode,
         saveAs: { fn -> fn.substring(fn.lastIndexOf('/')+1) },
     )

--- a/modules/local/clipkit.nf
+++ b/modules/local/clipkit.nf
@@ -28,7 +28,7 @@ process CLIPKIT {
     prefix=\$(basename "${fasta}" -mafft.fa)
 
     # Trim the MSAs for each orthogroup containing at least 4 species.
-    clipkit ${fasta} -o \$prefix-clipkit.fa
+    clipkit ${fasta} -o \$prefix-clipkit.fa $args
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/filter_orthogroups.nf
+++ b/modules/local/filter_orthogroups.nf
@@ -34,11 +34,6 @@ process FILTER_ORTHOGROUPS {
 
     script:
     def args = task.ext.args ?: ''
-    def num_spp = min_num_spp ? "${min_num_spp}" : '4'
-    def num_grp = min_num_groups ? "${min_num_groups}" : '2'
-    def copy_num1 = max_copy_num_filt1 ? "${max_copy_num_filt1}" : '5'
-    def copy_num2 = max_copy_num_filt2 ? "${max_copy_num_filt2}" : '10'
-
     """
     # The below summarizes the distribution of orthogroups across
     # species and across taxonomic groups, filtering them for
@@ -48,7 +43,7 @@ process FILTER_ORTHOGROUPS {
     ogSppCounts=${orthofinder_outdir}/Orthogroups/Orthogroups.GeneCount.tsv
 
     # Run the scripts to generate the orthogroup species/taxa gene count summaries and filtered sets
-    og-tax-summary.R \$ogSppCounts $samplesheet $num_spp $num_grp $copy_num1 $copy_num2
+    og-tax-summary.R \$ogSppCounts $samplesheet $min_num_spp $min_num_groups $max_copy_num_filt1 $max_copy_num_filt2
 
     # Add a column of filepaths to these
     msaDir=\$( cd ${orthofinder_outdir}/Orthogroup_Sequences/; pwd )

--- a/modules/local/generax.nf
+++ b/modules/local/generax.nf
@@ -37,11 +37,8 @@ process GENERAX {
     generax \
     --species-tree $init_species_tree \
     --families $families \
-    --rec-model UndatedDTL \
-    --prune-species-tree \
-    --per-family-rates \
-    --strategy SPR \
-    --prefix GeneRax
+    --prefix GeneRax \
+    $args
     
     # Rename the inferred reconciled gene trees to be named after their corresponding orthogroup
     for og in \$(ls GeneRax/results/)

--- a/modules/local/nf-core-modified/diamond_blastp.nf
+++ b/modules/local/nf-core-modified/diamond_blastp.nf
@@ -14,7 +14,6 @@ process DIAMOND_BLASTP {
     each path(db)
     val output_extension
     val mcl_test
-    val blast_columns
 
     output:
     path('*.blast*') , optional: true, emit: blast
@@ -32,7 +31,6 @@ process DIAMOND_BLASTP {
     script:
     def args = task.ext.args ?: ''
     def testing_mcl = mcl_test.equals('true') ? "${mcl_test}" : "false"
-    def columns = blast_columns ? "${blast_columns}" : ''
     switch ( output_extension ) {
         case "blast": outfmt = 0; break
         case "xml": outfmt = 5; break

--- a/modules/local/nf-core-modified/diamond_blastp.nf
+++ b/modules/local/nf-core-modified/diamond_blastp.nf
@@ -59,7 +59,7 @@ process DIAMOND_BLASTP {
     diamond \\
         blastp \\
         --out \$outName \\
-        --outfmt ${outfmt} ${columns} \\
+        --outfmt ${outfmt} \\
         --threads ${task.cpus} \\
         --query $fasta \\
         --compress 1 \\

--- a/modules/local/nf-core-modified/iqtree.nf
+++ b/modules/local/nf-core-modified/iqtree.nf
@@ -9,7 +9,7 @@ process IQTREE {
         'quay.io/biocontainers/iqtree:2.1.4_beta--hdcc8f71_0' }"
 
     input:
-    tuple path(alignment)
+    path(alignment)
     val model
     val pmsf_model
 

--- a/modules/local/nf-core-modified/mafft.nf
+++ b/modules/local/nf-core-modified/mafft.nf
@@ -28,9 +28,6 @@ process MAFFT {
 
     mafft \\
         --thread ${task.cpus} \\
-        --localpair \\
-        --maxiterate 1000 \\
-        --anysymbol \\
         ${fasta} \\
         > \$prefix-mafft.fa
 

--- a/modules/local/nf-core-modified/mafft.nf
+++ b/modules/local/nf-core-modified/mafft.nf
@@ -29,7 +29,7 @@ process MAFFT {
     mafft \\
         --thread ${task.cpus} \\
         ${fasta} \\
-        > \$prefix-mafft.fa
+        ${args} > \$prefix-mafft.fa
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/nf-core-modified/mafft.nf
+++ b/modules/local/nf-core-modified/mafft.nf
@@ -28,8 +28,7 @@ process MAFFT {
 
     mafft \\
         --thread ${task.cpus} \\
-        ${fasta} \\
-        ${args} > \$prefix-mafft.fa
+        ${args} ${fasta} > \$prefix-mafft.fa
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/nf-core-modified/mafft.nf
+++ b/modules/local/nf-core-modified/mafft.nf
@@ -27,7 +27,7 @@ process MAFFT {
     prefix=\$(basename "${fasta}" .fa)
 
     mafft \\
-        --thread ${task.cpus} \\
+        --thread -1 \\
         ${args} ${fasta} > \$prefix-mafft.fa
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/orthofinder_mcl.nf
+++ b/modules/local/orthofinder_mcl.nf
@@ -22,7 +22,6 @@ process ORTHOFINDER_MCL {
 
     script:
     def args = task.ext.args ?: ''
-    def inflation_param = mcl_inflation ? "${mcl_inflation}" : '1.5'
 
     """
     for f in \$(ls TestBlast*)
@@ -32,8 +31,8 @@ process ORTHOFINDER_MCL {
 
     orthofinder \\
         -b ./ \\
-        -n "Inflation_${inflation_param}" \\
-        -I $inflation_param \\
+        -n "Inflation_${mcl_inflation}" \\
+        -I $mcl_inflation \\
         -M msa -X -os -z \\
         -a ${task.cpus} \\
         $args

--- a/modules/local/orthofinder_mcl.nf
+++ b/modules/local/orthofinder_mcl.nf
@@ -38,6 +38,13 @@ process ORTHOFINDER_MCL {
         -a ${task.cpus} \\
         $args
 
+    # Check if we're running an mcl test or not:
+    # if so, delete the sequence files, which we will not be using and take up
+    # significant, unnecessary space. 
+    if [ "$output_directory" == "mcl_test_dataset" ]; then
+        rm -r Orthogroup_Sequences/
+    fi
+    
     # Restructure to get rid of the unnecessary "OrthoFinder" directory"
     mv OrthoFinder ${output_directory}
     """

--- a/modules/local/orthofinder_mcl.nf
+++ b/modules/local/orthofinder_mcl.nf
@@ -36,12 +36,12 @@ process ORTHOFINDER_MCL {
         -M msa -X -os -z \\
         -a ${task.cpus} \\
         $args
-
+    
     # Check if we're running an mcl test or not:
     # if so, delete the sequence files, which we will not be using and take up
     # significant, unnecessary space. 
     if [ "$output_directory" == "mcl_test_dataset" ]; then
-        rm -r Orthogroup_Sequences/
+        rm -r OrthoFinder/*/Orthogroup_Sequences/
     fi
     
     # Restructure to get rid of the unnecessary "OrthoFinder" directory"

--- a/modules/local/orthofinder_prep.nf
+++ b/modules/local/orthofinder_prep.nf
@@ -1,6 +1,6 @@
 process ORTHOFINDER_PREP {
     tag "Prepping data for OrthoFinder"
-    label 'process_low'
+    label 'process_medium'
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/orthofinder:2.5.4--hdfd78af_0' :
         'quay.io/biocontainers/orthofinder:2.5.4--hdfd78af_0' }"

--- a/modules/local/speciesrax.nf
+++ b/modules/local/speciesrax.nf
@@ -39,14 +39,8 @@ process SPECIESRAX {
     generax \
     --species-tree $init_species_tree \
     --families $families \
-    --per-family-rates \
-    --rec-model UndatedDTL \
-    --prune-species-tree \
-    --si-strategy HYBRID \
-    --si-quartet-support \
-    --si-estimate-bl \
-    --strategy SPR \
-    --prefix SpeciesRax
+    --prefix SpeciesRax \
+    $args
 
     # Copy the final starting tree to the current working directory -
     # this will be used as the starting tree for generax application to the

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,12 +12,25 @@ params {
     // TODO nf-core: Specify your pipeline's command line flags
     // Input options
     input                      = null
-    mcl_inflation              = null
-    busco_lineages_path        = null
+    
+    // OrthoFinder MCL inflation parameters to test
+    mcl_inflation              = '1.0,2.0,3.0'
 
     // BUSCO options
-    lineage                    = null
-    config_file                = null
+    busco_lineages_path        = null
+
+    // Annotation options
+    download_annots = 'none'
+    
+    // Orthogroup filtering options
+    min_num_spp_per_og = 4
+    min_num_grp_per_og = 1
+    max_copy_num_spp_tree = 5
+    max_copy_num_gene_trees = 10
+    
+    // IQ-TREE options
+    tree_model = 'TEST'
+    tree_model_pmsf = 'none'
 
     // Boilerplate options
     outdir                     = null
@@ -33,16 +46,6 @@ params {
     show_hidden_params         = false
     schema_ignore_params       = 'genomes'
     enable_conda               = false
-
-
-    // Config options
-    custom_config_version      = 'master'
-    custom_config_base         = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
-    config_profile_description = null
-    config_profile_contact     = null
-    config_profile_url         = null
-    config_profile_name        = null
-
 
     // Max resource options
     // Defaults only, expecting to be overwritten

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,7 +29,7 @@ params {
     max_copy_num_gene_trees = 10
     
     // IQ-TREE options
-    tree_model = 'TEST'
+    tree_model = 'LG+F+G4'
     tree_model_pmsf = 'none'
 
     // Boilerplate options

--- a/nextflow.config
+++ b/nextflow.config
@@ -47,6 +47,14 @@ params {
     schema_ignore_params       = 'genomes'
     enable_conda               = false
 
+    // Config options
+    custom_config_version      = 'master'
+    custom_config_base         = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
+    config_profile_description = null
+    config_profile_contact     = null
+    config_profile_url         = null
+    config_profile_name        = null
+    
     // Max resource options
     // Defaults only, expecting to be overwritten
     max_memory                 = '128.GB'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,7 +10,11 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": ["input", "mcl_inflation", "outdir"],
+            "required": [
+                "input",
+                "mcl_inflation",
+                "outdir"
+            ],
             "properties": {
                 "input": {
                     "type": "string",
@@ -95,7 +99,14 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
+                    "enum": [
+                        "symlink",
+                        "rellink",
+                        "link",
+                        "copy",
+                        "copyNoFollow",
+                        "move"
+                    ],
                     "hidden": true
                 },
                 "email_on_fail": {
@@ -165,5 +176,47 @@
         {
             "$ref": "#/definitions/generic_options"
         }
-    ]
+    ],
+    "properties": {
+        "busco_lineages_path": {
+            "type": "string",
+            "default": "None",
+            "description": "Optional path to where BUSCO lineage datasets are stored remotely (e.g. on S3)."
+        },
+        "download_annots": {
+            "type": "string",
+            "default": "none",
+            "description": "Option specifying the protein annotations the user would like to download. See README for a description of options."
+        },
+        "min_num_spp_per_og": {
+            "type": "integer",
+            "default": 4,
+            "description": "Minimum number of species included in orthogroup required for inference of MSA, gene family tree, and inclusion in species tree inference."
+        },
+        "min_num_grp_per_og": {
+            "type": "integer",
+            "default": 1,
+            "description": "Minimum number of higher-level taxonomic groups included in orthogroup required for inference of MSA, gene family tree, and inclusion in species tree inference."
+        },
+        "max_copy_num_spp_tree": {
+            "type": "integer",
+            "default": 5,
+            "description": "Maximum mean per-species orthogroup gene copy allowed for species tree inference."
+        },
+        "max_copy_num_gene_trees": {
+            "type": "integer",
+            "default": 10,
+            "description": "Maximum mean per-species orthogroup gene copy allowed for gene family tree / species tree reconciliation."
+        },
+        "tree_model": {
+            "type": "string",
+            "default": "TEST",
+            "description": "AA/nucleotide substitution model used by IQ-TREE for gene family tree inference. Determined automatically by default."
+        },
+        "tree_model_pmsf": {
+            "type": "string",
+            "default": "none",
+            "description": "Optional posterior mean site frequency (PMSF) approximation model for IQ-TREE. Conducts a second round of phylogenetic inference, using a guide tree inferred using the \"tree_model\" parameter specification."
+        }
+    }
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -217,6 +217,30 @@
             "type": "string",
             "default": "none",
             "description": "Optional posterior mean site frequency (PMSF) approximation model for IQ-TREE. Conducts a second round of phylogenetic inference, using a guide tree inferred using the \"tree_model\" parameter specification."
+        },
+        "custom_config_version": {
+            "type": "string",
+            "default": "master"
+        },
+        "custom_config_base": {
+            "type": "string",
+            "default": "https://raw.githubusercontent.com/nf-core/configs/master"
+        },
+        "config_profile_description": {
+            "type": "string",
+            "default": null
+        },
+        "config_profile_contact": {
+            "type": "string",
+            "default": null
+        },
+        "config_profile_url": {
+            "type": "string",
+            "default": null
+        },
+        "config_profile_name": {
+            "type": "string",
+            "default": null
         }
     }
 }

--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -20,10 +20,15 @@ workflow INPUT_CHECK {
     complete_prots.filter {
         it[0].mcl_test == 'true'
     }.set { mcl_test_prots }
+    
+    complete_prots.filter {
+        it[0].uniprot == 'true'
+    }.set { uniprot_prots }
 
     emit:
     complete_prots                            // channel: [ val(meta), [ complete_prots ] ]
     mcl_test_prots                            // channel: [ val(meta), [ mcl_test_prots ] ]
+    uniprot_prots                             // channel: [ val(meta), [ uniprot_prots ] ]
     complete_samplesheet = SAMPLESHEET_CHECK.out.csv
     versions = SAMPLESHEET_CHECK.out.versions // channel: [ versions.yml ]
 }

--- a/test/parameters.json
+++ b/test/parameters.json
@@ -1,5 +1,0 @@
-{
-  "input": "/home/ubuntu/environment/github/phylorthology/test/complete_samplesheet_s3.csv",
-  "outdir": "/home/ubuntu/environment/github/phylorthology/test",
-  "mcl_inflation": [ "1.0","2.0", "3.0", "4.0", "5.0" ]
-}

--- a/workflows/phylorthology.nf
+++ b/workflows/phylorthology.nf
@@ -26,6 +26,29 @@ if (params.mcl_inflation) {
     exit 1, 'MCL Inflation parameter(s) not specified!'
 }
 
+// Set custom parameters to either user-specified or default values. 
+// Set the filtering parameters:
+// Try to use user-specified values, otherwise use defaults.
+if (params.min_num_spp_per_og) {
+    ch_min_num_spp = Channel.of(params.min_num_spp_per_og)
+} else {
+    ch_min_num_spp = Channel.of('4')
+}
+if (params.min_num_grp_per_og) {
+    ch_min_num_grp = Channel.of(params.min_num_grp_per_og)
+} else {
+    ch_min_num_grp = Channel.of('1')
+}
+if (params.max_copy_num_spp_tree) {
+    ch_max_copy_num1 = Channel.of(params.max_copy_num_spp_tree)
+} else {
+    ch_max_copy_num1 = Channel.of('5')
+}
+if (params.max_copy_num_gene_trees) {
+    ch_max_copy_num2 = Channel.of(params.max_copy_num_gene_trees)
+} else {
+    ch_max_copy_num2 = Channel.of('10')
+}
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     IMPORT LOCAL MODULES/SUBWORKFLOWS
@@ -212,14 +235,13 @@ workflow PHYLORTHOLOGY {
     // across species and taxonomic group.
     // The conservative subset will be used for species tree inference,
     // and the remainder will be used to infer gene family trees only.
-    // TODO: parametrize the variables here
     FILTER_ORTHOGROUPS (
         INPUT_CHECK.out.complete_samplesheet,
         ORTHOFINDER_MCL.out.inflation_dir,
-        "4",
-        "4",
-        "1",
-        "2"
+        ch_min_num_spp,
+        ch_min_num_grp,
+        ch_max_copy_num1,
+        ch_max_copy_num2
     )
 
     //

--- a/workflows/phylorthology.nf
+++ b/workflows/phylorthology.nf
@@ -93,6 +93,7 @@ workflow PHYLORTHOLOGY {
     ch_versions = ch_versions.mix(INPUT_CHECK.out.versions)
     complete_prots_list = ch_all_data.complete_prots.collect { it[1] }
     mcl_test_prots_list = ch_all_data.mcl_test_prots.collect { it[1] }
+    uniprot_prots_list = ch_all_data.uniprot_prots.collect { it[1] }
 
     //
     // MODULE: Run BUSCO
@@ -119,8 +120,7 @@ workflow PHYLORTHOLOGY {
     //
     // MODULE: Annotate UniProt Proteins
     //
-    //ch_all_data_ann = ch_download_annots.combine(ch_all_data.complete_prots)
-    ANNOTATE_UNIPROT(ch_all_data.complete_prots, params.download_annots)
+    ANNOTATE_UNIPROT(ch_all_data.uniprot_prots, params.download_annots)
         .cogeqc_annotations
         .collect()
         .set { ch_annotations }

--- a/workflows/phylorthology.nf
+++ b/workflows/phylorthology.nf
@@ -126,18 +126,19 @@ workflow PHYLORTHOLOGY {
         []
     )
 
-    // Broad taxonomic scale (Eukaryotes)
-    BUSCO_BROAD (
-        ch_all_data.complete_prots,
-        "broad",
-        [],
-        []
-    )
+    // // Broad taxonomic scale (Eukaryotes)
+    // BUSCO_BROAD (
+    //     ch_all_data.complete_prots,
+    //     "broad",
+    //     [],
+    //     []
+    // )
 
     //
     // MODULE: Annotate UniProt Proteins
     //
-    ANNOTATE_UNIPROT(ch_all_data.complete_prots, ch_download_annots)
+    ch_all_data_ann = ch_download_annots.combine(ch_all_data.complete_prots)
+    ANNOTATE_UNIPROT(ch_all_data_ann)
         .cogeqc_annotations
         .collect()
         .set { ch_annotations }

--- a/workflows/phylorthology.nf
+++ b/workflows/phylorthology.nf
@@ -27,28 +27,20 @@ if (params.mcl_inflation) {
 }
 
 // Set custom parameters to either user-specified or default values. 
-// Set the filtering parameters:
 // Try to use user-specified values, otherwise use defaults.
 if (params.min_num_spp_per_og) {
     ch_min_num_spp = Channel.of(params.min_num_spp_per_og)
-} else {
-    ch_min_num_spp = Channel.of('4')
-}
+} else { ch_min_num_spp = Channel.of('4') }
 if (params.min_num_grp_per_og) {
     ch_min_num_grp = Channel.of(params.min_num_grp_per_og)
-} else {
-    ch_min_num_grp = Channel.of('1')
-}
+} else { ch_min_num_grp = Channel.of('1') }
 if (params.max_copy_num_spp_tree) {
     ch_max_copy_num1 = Channel.of(params.max_copy_num_spp_tree)
-} else {
-    ch_max_copy_num1 = Channel.of('5')
-}
+} else { ch_max_copy_num1 = Channel.of('5') }
 if (params.max_copy_num_gene_trees) {
     ch_max_copy_num2 = Channel.of(params.max_copy_num_gene_trees)
-} else {
-    ch_max_copy_num2 = Channel.of('10')
-}
+} else { ch_max_copy_num2 = Channel.of('10') }
+
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     IMPORT LOCAL MODULES/SUBWORKFLOWS

--- a/workflows/phylorthology.nf
+++ b/workflows/phylorthology.nf
@@ -126,13 +126,13 @@ workflow PHYLORTHOLOGY {
         []
     )
 
-    // // Broad taxonomic scale (Eukaryotes)
-    // BUSCO_BROAD (
-    //     ch_all_data.complete_prots,
-    //     "broad",
-    //     [],
-    //     []
-    // )
+    // Broad taxonomic scale (Eukaryotes)
+    BUSCO_BROAD (
+        ch_all_data.complete_prots,
+        "broad",
+        [],
+        []
+    )
 
     //
     // MODULE: Annotate UniProt Proteins

--- a/workflows/phylorthology.nf
+++ b/workflows/phylorthology.nf
@@ -157,8 +157,7 @@ workflow PHYLORTHOLOGY {
         ORTHOFINDER_PREP_TEST.out.fastas.flatten(),
         ORTHOFINDER_PREP_TEST.out.diamonds.flatten(),
         "txt",
-        "true",
-        []
+        "true"
     )
 
     // And for the full dataset, to be clustered into orthogroups using
@@ -168,8 +167,7 @@ workflow PHYLORTHOLOGY {
         ORTHOFINDER_PREP.out.fastas.flatten(),
         ORTHOFINDER_PREP.out.diamonds.flatten(),
         "txt",
-        "false",
-        []
+        "false"
     )
     ch_versions = ch_versions.mix(DIAMOND_BLASTP.out.versions)
 

--- a/workflows/phylorthology.nf
+++ b/workflows/phylorthology.nf
@@ -40,6 +40,9 @@ if (params.max_copy_num_spp_tree) {
 if (params.max_copy_num_gene_trees) {
     ch_max_copy_num2 = Channel.of(params.max_copy_num_gene_trees)
 } else { ch_max_copy_num2 = Channel.of('10') }
+if (params.download_annots) {
+    ch_download_annots = Channel.of(params.download_annots)
+} else { ch_download_annots = Channel.of('none') }
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -134,9 +137,10 @@ workflow PHYLORTHOLOGY {
     //
     // MODULE: Annotate UniProt Proteins
     //
-    ch_annotations = ANNOTATE_UNIPROT(ch_all_data.complete_prots)
+    ANNOTATE_UNIPROT(ch_all_data.complete_prots, ch_download_annots)
         .cogeqc_annotations
         .collect()
+        .set { ch_annotations }
     ch_versions = ch_versions.mix(ANNOTATE_UNIPROT.out.versions)
 
     //


### PR DESCRIPTION
This PR includes multiple changes that convert numerous previously hard-coded software parameters into actual nextflow parameters. These are now specified either in the parameter file (json), or in the modules.config file. Default parameters are now specified in base.config. 

This PR corresponds to the following issue, which outlines the problem, and for each fix indicates where/how parameterization was conducted: https://github.com/Arcadia-Science/phylorthology/issues/27. 

Changes to iqtree were most extensive - previously the user was forced to use a complex model of amino acid substitution, which involved running iqtree once, inferring a guide tree, and running a second time using that tree. I now include two parameters for iqtree: tree_model, and tree_model_pmsf. The first has a default (iqtree will automatically determine this) whereas the second does not. The second stage (for pmsf) will only run if this is specified in the parameterfile.

Additionally, I include a check in the "orthofinder prep" module that will only write out the sequence files (potentially >10-20 thousands of them per value of MCL inflation) if we are not at the MCL testing stage and are running the analysis in full. This will save tons of storage space and make cleanup more straightforward. 